### PR TITLE
Add Clone and Debug to Request

### DIFF
--- a/ehttp/src/types.rs
+++ b/ehttp/src/types.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 /// A simple http request.
+#[derive(Clone, Debug)]
 pub struct Request {
     /// "GET", "POST", …
     pub method: String,


### PR DESCRIPTION
The use of created `requests` in other threads is easily enabled by the Clone trait.