### PR TITLE
Streaming fetch

### DIFF
--- a/ehttp/Cargo.toml
+++ b/ehttp/Cargo.toml
@@ -49,12 +49,12 @@ futures-util = { version = "0.3", optional = true }
 [dependencies.web-sys]
 version = "0.3.52"
 features = [
+  "AbortSignal",
   "Headers",
+  "ReadableStream",
   "Request",
   "RequestInit",
   "RequestMode",
   "Response",
-  "AbortSignal",
-  "ReadableStream",
   "Window",
 ]

--- a/ehttp/Cargo.toml
+++ b/ehttp/Cargo.toml
@@ -17,10 +17,13 @@ include = ["../LICENSE-APACHE", "../LICENSE-MIT", "**/*.rs", "Cargo.toml"]
 all-features = true
 
 [features]
-streaming = ["dep:wasm-streams", "dep:futures-util"]
 "default" = []
+
 # To support fetch_async on native
 "native-async" = ["async-channel"]
+
+# To support streaming fetch
+streaming = ["dep:wasm-streams", "dep:futures-util"]
 
 [lib]
 

--- a/ehttp/Cargo.toml
+++ b/ehttp/Cargo.toml
@@ -13,6 +13,9 @@ categories = ["network-programming", "wasm", "web-programming"]
 keywords = ["http", "wasm", "native", "web"]
 include = ["../LICENSE-APACHE", "../LICENSE-MIT", "**/*.rs", "Cargo.toml"]
 
+[features]
+streaming = ["dep:wasm-streams", "dep:futures-util"]
+
 [package.metadata.docs.rs]
 all-features = true
 
@@ -37,6 +40,11 @@ js-sys = "0.3"
 wasm-bindgen = "0.2.86"
 wasm-bindgen-futures = "0.4"
 
+# Streaming response
+wasm-streams = { version = "0.3", optional = true }
+futures-util = { version = "0.3", optional = true }
+
+
 [dependencies.web-sys]
 version = "0.3.52"
 features = [
@@ -45,5 +53,7 @@ features = [
   "RequestInit",
   "RequestMode",
   "Response",
+  "AbortSignal",
+  "ReadableStream",
   "Window",
 ]

--- a/ehttp/Cargo.toml
+++ b/ehttp/Cargo.toml
@@ -13,13 +13,11 @@ categories = ["network-programming", "wasm", "web-programming"]
 keywords = ["http", "wasm", "native", "web"]
 include = ["../LICENSE-APACHE", "../LICENSE-MIT", "**/*.rs", "Cargo.toml"]
 
-[features]
-streaming = ["dep:wasm-streams", "dep:futures-util"]
-
 [package.metadata.docs.rs]
 all-features = true
 
 [features]
+streaming = ["dep:wasm-streams", "dep:futures-util"]
 "default" = []
 # To support fetch_async on native
 "native-async" = ["async-channel"]

--- a/ehttp/src/lib.rs
+++ b/ehttp/src/lib.rs
@@ -56,6 +56,9 @@ mod web;
 #[cfg(target_arch = "wasm32")]
 pub use web::spawn_future;
 
+#[cfg(feature = "streaming")]
+pub mod streaming;
+
 /// Helper for constructing [`Request::headers`].
 /// ```
 /// use ehttp::Request;

--- a/ehttp/src/lib.rs
+++ b/ehttp/src/lib.rs
@@ -44,7 +44,7 @@ pub async fn fetch_async(request: Request) -> Result<Response> {
 }
 
 mod types;
-pub use types::{Error, Request, Response, Result};
+pub use types::{Error, PartialResponse, Request, Response, Result};
 
 #[cfg(not(target_arch = "wasm32"))]
 mod native;

--- a/ehttp/src/streaming/mod.rs
+++ b/ehttp/src/streaming/mod.rs
@@ -2,7 +2,10 @@ use crate::Request;
 
 /// Performs a HTTP requests and calls the given callback once for the initial response,
 /// and then once for each chunk in the response body.
-pub fn fetch(request: Request, on_data: impl 'static + Send + Fn(crate::Result<types::Part>)) {
+pub fn fetch(
+    request: Request,
+    on_data: impl 'static + Send + Fn(crate::Result<types::Part>) -> Control,
+) {
     #[cfg(not(target_arch = "wasm32"))]
     native::fetch_streaming(request, Box::new(on_data));
 
@@ -22,4 +25,4 @@ pub use web::fetch_async_streaming;
 
 mod types;
 
-pub use self::types::{Part, Response};
+pub use self::types::{Control, Part};

--- a/ehttp/src/streaming/mod.rs
+++ b/ehttp/src/streaming/mod.rs
@@ -1,3 +1,44 @@
+//! Streaming HTTP client for both native and WASM.
+//!
+//! Example:
+//! ```
+//! let url = "https://www.example.com";
+//! let request = ehttp::Request::get(url);
+//! ehttp::streaming::fetch(request, move |result: ehttp::Result<ehttp::streaming::Part>| {
+//!     let part = match result {
+//!         Ok(part) => part,
+//!         Err(err) => {
+//!             eprintln!("an error occurred while streaming `{url}`: {err}");
+//!             return std::ops::ControlFlow::Break(());
+//!         }
+//!     }
+//!
+//!     match part {
+//!         ehttp::streaming::Part::Response(response) => {
+//!             println!("Status code: {:?}", response.status);
+//!             if !response.ok {
+//!                 std::ops::ControlFlow::Break(())
+//!             } else {
+//!                 std::ops::ControlFlow::Continue(())
+//!             }
+//!         }
+//!         ehttp::streaming::Part::Chunk(chunk) => {
+//!             match your_chunk_handler(chunk) {
+//!                 Ok(()) => std::ops::ControlFlow::Continue(()),
+//!                 Err(err) => {
+//!                     eprintln!("an error occurred while streaming `{url}`: {err}");
+//!                     std::ops::ControlFlow::Break(())
+//!                 }
+//!             }
+//!         }
+//!     }
+//! });
+//! ```
+//!
+//! The streaming fetch works like the non-streaming fetch, but instead
+//! of receiving the response in full, you receive parts of the response
+//! as they are streamed in.
+
 use std::ops::ControlFlow;
 
 use crate::Request;

--- a/ehttp/src/streaming/mod.rs
+++ b/ehttp/src/streaming/mod.rs
@@ -1,10 +1,12 @@
+use std::ops::ControlFlow;
+
 use crate::Request;
 
 /// Performs a HTTP requests and calls the given callback once for the initial response,
 /// and then once for each chunk in the response body.
 pub fn fetch(
     request: Request,
-    on_data: impl 'static + Send + Fn(crate::Result<types::Part>) -> Control,
+    on_data: impl 'static + Send + Fn(crate::Result<types::Part>) -> ControlFlow<()>,
 ) {
     #[cfg(not(target_arch = "wasm32"))]
     native::fetch_streaming(request, Box::new(on_data));
@@ -25,4 +27,4 @@ pub use web::fetch_async_streaming;
 
 mod types;
 
-pub use self::types::{Control, Part};
+pub use self::types::Part;

--- a/ehttp/src/streaming/mod.rs
+++ b/ehttp/src/streaming/mod.rs
@@ -4,6 +4,8 @@ use crate::Request;
 
 /// Performs a HTTP requests and calls the given callback once for the initial response,
 /// and then once for each chunk in the response body.
+///
+/// You can abort the fetch by returning [`ControlFlow::Break`] from the callback.
 pub fn fetch(
     request: Request,
     on_data: impl 'static + Send + Fn(crate::Result<types::Part>) -> ControlFlow<()>,

--- a/ehttp/src/streaming/mod.rs
+++ b/ehttp/src/streaming/mod.rs
@@ -1,0 +1,25 @@
+use crate::Request;
+
+/// Performs a HTTP requests and calls the given callback once for the initial response,
+/// and then once for each chunk in the response body.
+pub fn fetch(request: Request, on_data: impl 'static + Send + Fn(crate::Result<types::Part>)) {
+    #[cfg(not(target_arch = "wasm32"))]
+    native::fetch_streaming(request, Box::new(on_data));
+
+    #[cfg(target_arch = "wasm32")]
+    web::fetch_streaming(request, Box::new(on_data));
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native;
+#[cfg(not(target_arch = "wasm32"))]
+pub use native::fetch_streaming_blocking;
+
+#[cfg(target_arch = "wasm32")]
+mod web;
+#[cfg(target_arch = "wasm32")]
+pub use web::fetch_async_streaming;
+
+mod types;
+
+pub use self::types::{Part, Response};

--- a/ehttp/src/streaming/mod.rs
+++ b/ehttp/src/streaming/mod.rs
@@ -16,10 +16,10 @@
 //!     match part {
 //!         ehttp::streaming::Part::Response(response) => {
 //!             println!("Status code: {:?}", response.status);
-//!             if !response.ok {
-//!                 std::ops::ControlFlow::Break(())
-//!             } else {
+//!             if response.ok {
 //!                 std::ops::ControlFlow::Continue(())
+//!             } else {
+//!                 std::ops::ControlFlow::Break(())
 //!             }
 //!         }
 //!         ehttp::streaming::Part::Chunk(chunk) => {

--- a/ehttp/src/streaming/mod.rs
+++ b/ehttp/src/streaming/mod.rs
@@ -1,4 +1,6 @@
 //! Streaming HTTP client for both native and WASM.
+//! 
+//! Requires the `streaming` feature to be enabled.
 //!
 //! Example:
 //! ```

--- a/ehttp/src/streaming/mod.rs
+++ b/ehttp/src/streaming/mod.rs
@@ -1,5 +1,5 @@
 //! Streaming HTTP client for both native and WASM.
-//! 
+//!
 //! Requires the `streaming` feature to be enabled.
 //!
 //! Example:

--- a/ehttp/src/streaming/mod.rs
+++ b/ehttp/src/streaming/mod.rs
@@ -2,6 +2,15 @@
 //!
 //! Example:
 //! ```
+//! let your_chunk_handler = std::sync::Arc::new(|chunk: Vec<u8>| {
+//!     if chunk.is_empty() {
+//!         return std::ops::ControlFlow::Break(());
+//!     }
+//!
+//!     println!("received chunk: {} bytes", chunk.len());
+//!     std::ops::ControlFlow::Continue(())
+//! });
+//!
 //! let url = "https://www.example.com";
 //! let request = ehttp::Request::get(url);
 //! ehttp::streaming::fetch(request, move |result: ehttp::Result<ehttp::streaming::Part>| {
@@ -11,7 +20,7 @@
 //!             eprintln!("an error occurred while streaming `{url}`: {err}");
 //!             return std::ops::ControlFlow::Break(());
 //!         }
-//!     }
+//!     };
 //!
 //!     match part {
 //!         ehttp::streaming::Part::Response(response) => {
@@ -23,13 +32,7 @@
 //!             }
 //!         }
 //!         ehttp::streaming::Part::Chunk(chunk) => {
-//!             match your_chunk_handler(chunk) {
-//!                 Ok(()) => std::ops::ControlFlow::Continue(()),
-//!                 Err(err) => {
-//!                     eprintln!("an error occurred while streaming `{url}`: {err}");
-//!                     std::ops::ControlFlow::Break(())
-//!                 }
-//!             }
+//!             your_chunk_handler(chunk)
 //!         }
 //!     }
 //! });

--- a/ehttp/src/streaming/native.rs
+++ b/ehttp/src/streaming/native.rs
@@ -1,14 +1,14 @@
 use std::collections::BTreeMap;
+use std::ops::ControlFlow;
 
 use crate::Request;
 
-use super::Control;
 use super::Part;
 use crate::types::PartialResponse;
 
 pub fn fetch_streaming_blocking(
     request: Request,
-    on_data: Box<dyn Fn(crate::Result<Part>) -> Control + Send>,
+    on_data: Box<dyn Fn(crate::Result<Part>) -> ControlFlow<()> + Send>,
 ) {
     let mut req = ureq::request(&request.method, &request.url);
 
@@ -79,7 +79,7 @@ pub fn fetch_streaming_blocking(
 
 pub(crate) fn fetch_streaming(
     request: Request,
-    on_data: Box<dyn Fn(crate::Result<Part>) -> Control + Send>,
+    on_data: Box<dyn Fn(crate::Result<Part>) -> ControlFlow<()> + Send>,
 ) {
     std::thread::Builder::new()
         .name("ehttp".to_owned())

--- a/ehttp/src/streaming/native.rs
+++ b/ehttp/src/streaming/native.rs
@@ -60,7 +60,6 @@ pub fn fetch_streaming_blocking(
             Ok(n) if n > 0 => {
                 // clone data from buffer and clear it
                 let chunk = buf[..n].to_vec();
-                buf.fill(0);
                 if on_data(Ok(Part::Chunk(chunk))).is_break() {
                     return;
                 };

--- a/ehttp/src/streaming/types.rs
+++ b/ehttp/src/streaming/types.rs
@@ -1,30 +1,28 @@
-use std::collections::BTreeMap;
-
-pub struct Response {
-    /// The URL we ended up at. This can differ from the request url when we have followed redirects.
-    pub url: String,
-
-    /// Did we get a 2xx response code?
-    pub ok: bool,
-
-    /// Status code (e.g. `404` for "File not found").
-    pub status: u16,
-
-    /// Status text (e.g. "File not found" for status code `404`).
-    pub status_text: String,
-
-    /// The returned headers. All header names are lower-case.
-    pub headers: BTreeMap<String, String>,
-}
+use crate::types::PartialResponse;
 
 pub enum Part {
     /// The header of the response.
     ///
     /// The `on_data` callback receives this only once.
-    Response(Response),
+    Response(PartialResponse),
 
     /// A single chunk of the response data.
     ///
     /// If the chunk is empty, that means the `on_data` callback will not receive any more data.
     Chunk(Vec<u8>),
+}
+
+pub enum Control {
+    Continue,
+    Break,
+}
+
+impl Control {
+    pub fn is_break(&self) -> bool {
+        matches!(self, Self::Break)
+    }
+
+    pub fn is_continue(&self) -> bool {
+        matches!(self, Self::Continue)
+    }
 }

--- a/ehttp/src/streaming/types.rs
+++ b/ehttp/src/streaming/types.rs
@@ -11,18 +11,3 @@ pub enum Part {
     /// If the chunk is empty, that means the `on_data` callback will not receive any more data.
     Chunk(Vec<u8>),
 }
-
-pub enum Control {
-    Continue,
-    Break,
-}
-
-impl Control {
-    pub fn is_break(&self) -> bool {
-        matches!(self, Self::Break)
-    }
-
-    pub fn is_continue(&self) -> bool {
-        matches!(self, Self::Continue)
-    }
-}

--- a/ehttp/src/streaming/types.rs
+++ b/ehttp/src/streaming/types.rs
@@ -1,0 +1,30 @@
+use std::collections::BTreeMap;
+
+pub struct Response {
+    /// The URL we ended up at. This can differ from the request url when we have followed redirects.
+    pub url: String,
+
+    /// Did we get a 2xx response code?
+    pub ok: bool,
+
+    /// Status code (e.g. `404` for "File not found").
+    pub status: u16,
+
+    /// Status text (e.g. "File not found" for status code `404`).
+    pub status_text: String,
+
+    /// The returned headers. All header names are lower-case.
+    pub headers: BTreeMap<String, String>,
+}
+
+pub enum Part {
+    /// The header of the response.
+    ///
+    /// The `on_data` callback receives this only once.
+    Response(Response),
+
+    /// A single chunk of the response data.
+    ///
+    /// If the chunk is empty, that means the `on_data` callback will not receive any more data.
+    Chunk(Vec<u8>),
+}

--- a/ehttp/src/streaming/types.rs
+++ b/ehttp/src/streaming/types.rs
@@ -1,5 +1,6 @@
 use crate::types::PartialResponse;
 
+/// A piece streamed by [`crate::streaming::fetch`].
 pub enum Part {
     /// The header of the response.
     ///

--- a/ehttp/src/streaming/web.rs
+++ b/ehttp/src/streaming/web.rs
@@ -11,8 +11,8 @@ use super::types::Part;
 
 /// Only available when compiling for web.
 ///
-/// NOTE: Ok(…) is returned on network error.
-/// Err is only for failure to use the fetch api.
+/// NOTE: `Ok(…)` is returned on network error.
+/// `Err` is only for failure to use the fetch api.
 #[cfg(feature = "streaming")]
 pub async fn fetch_async_streaming(
     request: &Request,

--- a/ehttp/src/streaming/web.rs
+++ b/ehttp/src/streaming/web.rs
@@ -1,3 +1,5 @@
+use std::ops::ControlFlow;
+
 use futures_util::Stream;
 use futures_util::StreamExt;
 use wasm_bindgen::prelude::*;
@@ -6,7 +8,6 @@ use crate::web::{fetch_base, get_response_base, spawn_future, string_from_js_val
 use crate::Request;
 
 use super::types::Part;
-use super::Control;
 
 /// Only available when compiling for web.
 ///
@@ -47,7 +48,7 @@ async fn fetch_jsvalue_stream(
 
 pub(crate) fn fetch_streaming(
     request: Request,
-    on_data: Box<dyn Fn(crate::Result<Part>) -> Control + Send>,
+    on_data: Box<dyn Fn(crate::Result<Part>) -> ControlFlow<()> + Send>,
 ) {
     spawn_future(async move {
         let mut stream = match fetch_jsvalue_stream(&request).await {

--- a/ehttp/src/streaming/web.rs
+++ b/ehttp/src/streaming/web.rs
@@ -1,0 +1,68 @@
+use futures_util::Stream;
+use futures_util::StreamExt;
+use wasm_bindgen::prelude::*;
+
+use super::types::Response;
+use crate::web::{fetch_base, get_response_base, spawn_future, string_from_js_value};
+use crate::Request;
+
+use super::types::Part;
+
+/// Only available when compiling for web.
+///
+/// NOTE: Ok(…) is returned on network error.
+/// Err is only for failure to use the fetch api.
+#[cfg(feature = "streaming")]
+pub async fn fetch_async_streaming(
+    request: &Request,
+) -> crate::Result<impl Stream<Item = crate::Result<Part>>> {
+    let stream = fetch_jsvalue_stream(request)
+        .await
+        .map_err(string_from_js_value)?;
+    Ok(stream.map(|result| result.map_err(string_from_js_value)))
+}
+
+#[cfg(feature = "streaming")]
+async fn fetch_jsvalue_stream(
+    request: &Request,
+) -> Result<impl Stream<Item = Result<Part, JsValue>>, JsValue> {
+    use js_sys::Uint8Array;
+
+    let response = fetch_base(request).await?;
+    let body = wasm_streams::ReadableStream::from_raw(
+        response.body().ok_or("response has no body")?.dyn_into()?,
+    );
+
+    // returns a `Part::Response` followed by all the chunks in `body` as `Part::Chunk`
+    Ok(
+        futures_util::stream::once(futures_util::future::ready(Ok(Part::Response(
+            Response::from(get_response_base(&response)?),
+        ))))
+        .chain(
+            body.into_stream()
+                .map(|value| value.map(|value| Part::Chunk(Uint8Array::new(&value).to_vec()))),
+        ),
+    )
+}
+
+pub(crate) fn fetch_streaming(request: Request, on_data: Box<dyn Fn(crate::Result<Part>) + Send>) {
+    spawn_future(async move {
+        let mut stream = match fetch_jsvalue_stream(&request).await {
+            Ok(stream) => stream,
+            Err(e) => {
+                return on_data(Err(string_from_js_value(e)));
+            }
+        };
+
+        while let Some(chunk) = stream.next().await {
+            match chunk {
+                Ok(chunk) => on_data(Ok(chunk)),
+                Err(e) => {
+                    return on_data(Err(string_from_js_value(e)));
+                }
+            }
+        }
+
+        on_data(Ok(Part::Chunk(vec![])));
+    })
+}

--- a/ehttp/src/types.rs
+++ b/ehttp/src/types.rs
@@ -88,6 +88,24 @@ impl std::fmt::Debug for Response {
     }
 }
 
+/// An HTTP response status line and headers
+pub struct PartialResponse {
+    /// The URL we ended up at. This can differ from the request url when we have followed redirects.
+    pub url: String,
+
+    /// Did we get a 2xx response code?
+    pub ok: bool,
+
+    /// Status code (e.g. `404` for "File not found").
+    pub status: u16,
+
+    /// Status text (e.g. "File not found" for status code `404`).
+    pub status_text: String,
+
+    /// The returned headers. All header names are lower-case.
+    pub headers: BTreeMap<String, String>,
+}
+
 /// A description of an error.
 ///
 /// This is only used when we fail to make a request.

--- a/ehttp/src/types.rs
+++ b/ehttp/src/types.rs
@@ -88,7 +88,7 @@ impl std::fmt::Debug for Response {
     }
 }
 
-/// An HTTP response status line and headers
+/// An HTTP response status line and headers used for the [`streaming`](crate::streaming) API.
 pub struct PartialResponse {
     /// The URL we ended up at. This can differ from the request url when we have followed redirects.
     pub url: String,

--- a/ehttp/src/web.rs
+++ b/ehttp/src/web.rs
@@ -1,8 +1,7 @@
-use std::collections::BTreeMap;
-
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
+use crate::types::PartialResponse;
 use crate::{Request, Response};
 
 /// Only available when compiling for web.
@@ -42,15 +41,7 @@ pub(crate) async fn fetch_base(request: &Request) -> Result<web_sys::Response, J
     Ok(response)
 }
 
-pub(crate) struct ResponseBase {
-    pub url: String,
-    pub ok: bool,
-    pub status: u16,
-    pub status_text: String,
-    pub headers: BTreeMap<String, String>,
-}
-
-pub(crate) fn get_response_base(response: &web_sys::Response) -> Result<ResponseBase, JsValue> {
+pub(crate) fn get_response_base(response: &web_sys::Response) -> Result<PartialResponse, JsValue> {
     // https://developer.mozilla.org/en-US/docs/Web/API/Headers
     // "Note: When Header values are iterated over, […] values from duplicate header names are combined."
     let js_headers: web_sys::Headers = response.headers();
@@ -76,7 +67,7 @@ pub(crate) fn get_response_base(response: &web_sys::Response) -> Result<Response
         headers.insert(key, value);
     }
 
-    Ok(ResponseBase {
+    Ok(PartialResponse {
         url: response.url(),
         ok: response.ok(),
         status: response.status(),


### PR DESCRIPTION
Add `ehttp::streaming` when the `streaming` feature is enabled.

On the web, `ehttp::streaming::fetch` uses [wasm-streams](https://github.com/MattiasBuelens/wasm-streams) to handle the conversion of a Response body to a Rust async `Stream`.

On native, `ehttp::streaming::fetch` uses `ureq` the same way as blocking fetch, but using `into_reader` on the body instead of `read_to_end`.

