### PR TITLE
don't add web-sys to native builds

### DIFF
--- a/ehttp/Cargo.toml
+++ b/ehttp/Cargo.toml
@@ -46,8 +46,7 @@ wasm-bindgen-futures = "0.4"
 futures-util = { version = "0.3", optional = true }
 wasm-streams = { version = "0.4", optional = true }
 
-
-[dependencies.web-sys]
+[target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.52"
 features = [
   "AbortSignal",


### PR DESCRIPTION
Not sure if `web-sys` was intentionally added as a dependency to all builds? Does not seem to be required for native builds.