### PR TITLE
Add NodeJS support. Fixes #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Apache](https://img.shields.io/badge/license-Apache-blue.svg)
 
-If you want to do HTTP requests and are targeting both native and web (WASM), then this is the crate for you!
+If you want to do HTTP requests and are targeting both native, web (WASM) and NodeJS (since v18.0), then this is the crate for you!
 
 [You can try the web demo here](https://emilk.github.io/ehttp/index.html) (works in any browser with WASM and WebGL support). Uses [`eframe`](https://github.com/emilk/egui/tree/master/crates/eframe).
 

--- a/ehttp/src/web.rs
+++ b/ehttp/src/web.rs
@@ -4,6 +4,13 @@ use wasm_bindgen_futures::JsFuture;
 use crate::types::PartialResponse;
 use crate::{Request, Response};
 
+/// Binds the JavaScript `fetch` method for use in both Node.js (>= v18.0) and browser environments.
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_name = fetch)]
+    fn fetch_with_request(input: &web_sys::Request) -> js_sys::Promise;
+}
+
 /// Only available when compiling for web.
 ///
 /// NOTE: `Ok(…)` is returned on network error.
@@ -57,8 +64,7 @@ pub(crate) async fn fetch_base(request: &Request) -> Result<web_sys::Response, J
         js_request.headers().set(k, v)?;
     }
 
-    let window = web_sys::window().unwrap();
-    let response = JsFuture::from(window.fetch_with_request(&js_request)).await?;
+    let response = JsFuture::from(fetch_with_request(&js_request)).await?;
     let response: web_sys::Response = response.dyn_into()?;
 
     Ok(response)


### PR DESCRIPTION
Fixes #31.

Use a direct binding of fetch that is now available in NodeJS >= v18.0