### PR TITLE
fix README.md in example_eframe

### DIFF
--- a/example_eframe/README.md
+++ b/example_eframe/README.md
@@ -10,5 +10,5 @@ cargo run --release -p example_eframe
 ``` sh
 ./setup_web.sh
 ./start_server.sh &
-./build_web.sh --fast --open
+./build_web.sh --open
 ```


### PR DESCRIPTION
The --fast option does not exist (it was probably replaced with counter-party --release); a non-existing option causes a break in the script, effectively ignoring the --open option.