### PR TITLE
add proxy-from-env feature flag

### DIFF
--- a/ehttp/Cargo.toml
+++ b/ehttp/Cargo.toml
@@ -34,6 +34,9 @@ native-async = ["async-channel"]
 ## Support streaming fetch
 streaming = ["dep:wasm-streams", "dep:futures-util"]
 
+## Support proxy configuration from environment variables on native
+proxy-from-env = ["ureq/proxy-from-env"]
+
 
 [dependencies]
 document-features = "0.2"


### PR DESCRIPTION
Forwards to ureq/proxy-from-env (only works on native)

Partially addresses https://github.com/emilk/ehttp/issues/19